### PR TITLE
fixes npmi.co badge

### DIFF
--- a/templates/npm.md
+++ b/templates/npm.md
@@ -1,1 +1,1 @@
-[![NPM](https://nodei.co/npm/{%= name %}.svg)](https://nodei.co/npm/{%= name %}/)
+[![NPM](https://nodei.co/npm/{%= name %}.png)](https://nodei.co/npm/{%= name %}/)


### PR DESCRIPTION
there seems to be a problem with Github using the `svg` version. This should be changed back to `svg` as soon as it works on Github
