### PR TITLE
Fix bower link.

### DIFF
--- a/templates/bower.md
+++ b/templates/bower.md
@@ -1,1 +1,1 @@
-[![Bower](https://img.shields.io/bower/v/{%= name %}.svg)]()
+[![Bower](https://img.shields.io/bower/v/{%= name %}.svg)](https://github.com/{%= github.repopath %})


### PR DESCRIPTION
Instead of linking to nowhere, which results in a 404 link from a README, e.g. [https://github.com/adjohnson916/magnificent.js/blob/master](https://github.com/adjohnson916/magnificent.js/blob/master), the badge will link to the GitHub repo URL.
